### PR TITLE
Implement deep JSON-Schema validation

### DIFF
--- a/crates/toka-toolkit-core/Cargo.toml
+++ b/crates/toka-toolkit-core/Cargo.toml
@@ -15,7 +15,18 @@ tracing = "0.1"
 url = "2"
 jsonschema = "0.17"
 
+# Optional dependencies for advanced schema validation features
+once_cell = { version = "1.19", optional = true }
+dashmap = { version = "5.5", optional = true }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 anyhow = "1"
-async-trait = "0.1" 
+async-trait = "0.1"
+
+[features]
+# Enables in-memory cache for compiled JSON Schemas to reduce validation cost.
+schema_cache = ["once_cell", "dashmap"]
+
+# Allows remote $ref resolution inside JSON Schemas (use with caution).
+allow_remote_refs = [] 

--- a/crates/toka-toolkit-core/tests/manifest_schema_validation.rs
+++ b/crates/toka-toolkit-core/tests/manifest_schema_validation.rs
@@ -1,0 +1,60 @@
+use toka_toolkit_core::manifest::{ToolManifest, Schema, Transport};
+use serde_json::json;
+use anyhow::Result;
+
+fn base_manifest() -> ToolManifest {
+    ToolManifest {
+        id: "demo.tool".into(),
+        name: "Demo Tool".into(),
+        version: "0.1.0".into(),
+        description: "A demo tool".into(),
+        capability: "demo".into(),
+        side_effect: Default::default(),
+        input_schema: None,
+        output_schema: None,
+        transports: vec![Transport::InProcess],
+        action_id: None,
+        manifest_version: toka_toolkit_core::manifest::SCHEMA_VERSION.to_string(),
+        protocols: vec![],
+        metadata: Default::default(),
+    }
+}
+
+#[test]
+fn valid_schema_passes() -> Result<()> {
+    let mut mani = base_manifest();
+    let input = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string", "minLength": 1 } }
+    });
+    mani.input_schema = Some(Schema(input.to_string()));
+
+    mani.validate()?;
+    Ok(())
+}
+
+#[test]
+fn syntax_error_fails() {
+    let mut mani = base_manifest();
+    mani.input_schema = Some(Schema("{ not valid json".into()));
+    assert!(mani.validate().is_err());
+}
+
+#[test]
+fn remote_ref_disallowed() {
+    let mut mani = base_manifest();
+    let schema = json!({ "$ref": "https://example.com/schema.json" });
+    mani.input_schema = Some(Schema(schema.to_string()));
+    assert!(mani.validate().is_err());
+}
+
+#[test]
+fn oversize_schema_fails() {
+    let mut mani = base_manifest();
+    let big_prop = "a".repeat(70_000);
+    let schema = json!({ "type": "string", "x": big_prop });
+    mani.input_schema = Some(Schema(schema.to_string()));
+    assert!(mani.validate().is_err());
+}

--- a/docs/protocols/mcp_rust.md
+++ b/docs/protocols/mcp_rust.md
@@ -58,4 +58,40 @@ Run conformance tests locally:
 
 ```bash
 cargo test -p my_crate --features "mcp_conformance"
-``` 
+```
+
+## Example Schemas
+
+Below is a minimal set of **draft-07** JSON Schemas you can copy-paste when
+authoring a simple *echo* style tool.  They pass the new deep-validation logic
+introduced in `toka-toolkit-core` v0.1.1 and illustrate common best practices:
+
+```jsonc
+"input_schema": {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["text"],
+  "properties": {
+    "text": { "type": "string", "minLength": 1 }
+  }
+},
+"output_schema": {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["echo"],
+  "properties": {
+    "echo": { "type": "string" }
+  }
+}
+```
+
+### Guidelines
+
+* **Keep it small** – the tooling enforces a hard 64 KiB limit per schema.
+* **Avoid remote `$ref`** – they're disabled by default for security.  Enable
+  with the `allow_remote_refs` crate feature only if absolutely necessary.
+* **Draft compatibility** – target draft-07 today; *draft-2020-12* support will
+  land once the upstream crate is stable.
+
+See the *Tool Development Guidelines* for a broader discussion on capability
+design and side-effect classification. 


### PR DESCRIPTION
Implement deep JSON-Schema validation for `ToolManifest` to ensure correctness, security, and efficiency.

Previously, JSON schemas were only syntactically parsed due to lifetime issues preventing full `jsonschema` compilation. This PR introduces a helper routine to allow full draft-07 compilation without memory leaks. It also adds security measures such as a 64 KiB size limit and default rejection of remote `$ref`s, along with an optional in-memory cache for performance.