### PR TITLE
Fix errors in toka-memory changes

### DIFF
--- a/crates/toka-toolkit-core/tests/manifest_schema_validation.rs
+++ b/crates/toka-toolkit-core/tests/manifest_schema_validation.rs
@@ -42,12 +42,24 @@ fn syntax_error_fails() {
     assert!(mani.validate().is_err());
 }
 
+#[cfg(not(feature = "allow_remote_refs"))]
 #[test]
 fn remote_ref_disallowed() {
     let mut mani = base_manifest();
     let schema = json!({ "$ref": "https://example.com/schema.json" });
     mani.input_schema = Some(Schema(schema.to_string()));
     assert!(mani.validate().is_err());
+}
+
+#[cfg(feature = "allow_remote_refs")]
+#[test]
+fn remote_ref_allowed_feature_enabled() -> Result<()> {
+    let mut mani = base_manifest();
+    let schema = json!({ "$ref": "https://example.com/schema.json" });
+    mani.input_schema = Some(Schema(schema.to_string()));
+    // Should validate successfully when the feature is enabled
+    mani.validate()?;
+    Ok(())
 }
 
 #[test]

--- a/crates/toka-tools/src/lib.rs
+++ b/crates/toka-tools/src/lib.rs
@@ -48,4 +48,4 @@
 pub mod tools;
 
 // Re-export the important types so downstream code can simply `use toka_toolkit::{Tool, ToolRegistry}`
-pub use crate::tools::{Tool, ToolRegistry};
+pub use crate::tools::{Tool, ToolRegistry, ToolParams};


### PR DESCRIPTION
Fix `cargo test --workspace --all-features` errors by conditionally gating a test and re-exporting a type.

The `remote_ref_disallowed` test in `toka-toolkit-core` was failing when the `allow_remote_refs` feature was enabled, so it is now conditionally compiled. A new test for the allowed case was added. Additionally, `ToolParams` was re-exported in `toka-tools` to resolve compilation errors in doctests where it was expected to be public.