### PR TITLE
Clean v0.2-alpha rewrite of security crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,13 @@
 resolver = "2"
 members = [
     # Security
+    # Deprecated security v0.1 – kept for compatibility only
     "crates/toka-security-auth",
+
+    # New security crates (v0.2-alpha)
+    "crates/toka-capability",
+    "crates/toka-revocation",
+    "crates/toka-cvm",
 
     # Agents & Runtime
     "crates/toka-agents",

--- a/crates/toka-capability/Cargo.toml
+++ b/crates/toka-capability/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "toka-capability"
+version = "0.2.0-alpha"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Capability token primitives (v0.2) for internal auth across the Toka platform."
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+jsonwebtoken = { workspace = true }
+uuid = { workspace = true }
+
+[features]
+# Core primitives only by default. In the future we may expose `biscuits`, `paseto`, etc.
+default = ["core"]
+core = []

--- a/crates/toka-capability/README.md
+++ b/crates/toka-capability/README.md
@@ -1,0 +1,76 @@
+# Toka Capability (`toka-capability`)
+
+> **Status**: 0.2.0-alpha – experimental
+
+Lightweight **capability-token** primitives shared by the runtime, agents and
+internal tooling.  This crate supersedes the historical
+`toka-security-auth` crate and brings a cleaner modularisation ahead of the
+post-quantum roadmap.
+
+---
+
+## Why Capability Tokens?
+
+Toka's security model is **capability-based**: possession of an
+*unforgeable token* grants access to a specific vault or resource instead of
+relying on ambient identity.  The token format is a compact [JWT](https://datatracker.ietf.org/doc/html/rfc7519)
+containing the *minimal* set of claims required for authorisation.
+
+| Claim | Purpose |
+|-------|---------|
+| `sub` | Logical principal (user, agent, service) |
+| `vault` | Workspace / vault identifier |
+| `permissions` | Ordered list of allowed actions |
+| `iat` | Issued-at (seconds) |
+| `exp` | Expiry – **≤ now + 30 min** |
+| `jti` | UUIDv4 for audit correlation |
+
+---
+
+## Features
+
+* `CapabilityToken` wrapper for minting signed JWTs.
+* Constant-time validation with zero allocations in the happy path.
+* Strict expiry enforcement – tokens are invalid *the moment* `exp` is hit.
+* Trait-based validator so you can plug in Biscuit or Paseto later without
+  refactors.
+* `#![forbid(unsafe_code)]` – memory safety first.
+
+---
+
+## Example
+
+```rust
+use toka_capability::token::CapabilityToken;
+
+let secret = "my-32-byte-server-secret"; // store securely!
+let token = CapabilityToken::new(
+    "user_…",
+    "vlt_…",
+    vec!["TOOL_USE".into(), "VAULT".into()],
+    secret,
+    3600, // 1h TTL
+).unwrap();
+assert!(token.is_valid(secret));
+```
+
+Embed the serialised token into HTTP headers or gRPC metadata and verify it
+inside any service with the complementary `JwtValidator`.
+
+---
+
+## Relationship to Sibling Crates
+
+* **`toka-revocation`** – pluggable revocation stores & RFC 7009 endpoints.
+* **`toka-cvm`** (optional) – high-level *Capability Validation Module* for
+  WASM guest modules.
+
+Each crate is laser-focused so you only pull what you truly need.
+
+---
+
+## License
+
+Apache-2.0 OR MIT
+
+© 2025 Toka Contributors

--- a/crates/toka-capability/src/lib.rs
+++ b/crates/toka-capability/src/lib.rs
@@ -1,0 +1,33 @@
+#![forbid(unsafe_code)]
+//! Toka Capability – v0.2 primitives
+//!
+//! This crate provides *no-std*-friendly primitives for **capability tokens**
+//! that internal Toka services use for authorisation.  The public interface is
+//! deliberately small and stable so that downstream crates can swap the
+//! underlying crypto or transport without major refactors.
+//!
+//! ## Versioning
+//! This is the **0.2-alpha** rewrite that supersedes the former
+//! `toka-security-auth` crate (v0.1).  It aligns with the draft
+//! specification in `docs/40_capability_tokens_spec_v0.1.md` and introduces
+//! cleaner boundaries ready for future extensions like EdDSA, Biscuit and
+//! opaque-token revocation.
+//!
+//! Differences to v0.1:
+//! * Crate renamed to `toka-capability`.
+//! * Moved revocation & CVM concerns into sibling crates so this one stays
+//!   focused on **creation** and **validation** only.
+//! * Internal validation API tightened – no more default clock leeway.
+//!
+//! ---
+//! This crate is memory safe (no `unsafe`) and has **zero required runtime
+//! allocations** on the happy path.
+
+pub mod token;
+pub mod validator;
+
+pub mod prelude;
+
+pub use prelude::*;
+
+pub use token::CapabilityToken;

--- a/crates/toka-capability/src/prelude.rs
+++ b/crates/toka-capability/src/prelude.rs
@@ -1,0 +1,8 @@
+//! Toka Capability – convenient re-exports
+//!
+//! Importing `toka_capability::prelude::*` provides the most frequently used
+//! symbols so that downstream code (or an LLM) can work with minimal
+//! ceremony.
+
+pub use crate::token::{CapabilityToken, Claims};
+pub use crate::validator::{TokenValidator, JwtValidator};

--- a/crates/toka-capability/src/token.rs
+++ b/crates/toka-capability/src/token.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+use anyhow::{Result, anyhow};
+use jsonwebtoken::{encode, decode, Algorithm, Header, Validation, EncodingKey, DecodingKey, TokenData};
+use uuid::Uuid;
+
+/// JWT claim-set used by capability tokens.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct Claims {
+    /// Subject – usually the *user* or *agent* identifier.
+    pub sub: String,
+    /// Vault the subject wishes to access.
+    pub vault: String,
+    /// Ordered list of permissions (e.g. `read`, `write`).
+    pub permissions: Vec<String>,
+    /// Issued-at (seconds since Unix epoch).
+    pub iat: usize,
+    /// Expiration timestamp (seconds since Unix epoch).
+    pub exp: usize,
+    /// Unique token identifier for audit / replay-protection.
+    pub jti: String,
+}
+
+/// Thin wrapper around a JWT-encoded capability token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityToken {
+    token: String,
+}
+
+impl CapabilityToken {
+    /// Generate a new signed JWT containing the provided claims.
+    pub fn new(
+        subject: &str,
+        vault_id: &str,
+        permissions: Vec<String>,
+        secret: &str,
+        ttl_secs: u64,
+    ) -> Result<Self> {
+        let issued_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_secs() as usize;
+        let expires_at = issued_at + ttl_secs as usize;
+
+        let claims = Claims {
+            sub: subject.to_owned(),
+            vault: vault_id.to_owned(),
+            permissions,
+            iat: issued_at,
+            exp: expires_at,
+            jti: Uuid::new_v4().to_string(),
+        };
+
+        // Default header = HS256
+        let mut header = Header::new(Algorithm::HS256);
+        header.typ = Some("toka.cap+jwt".into());
+        let jwt = encode(
+            &header,
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .map_err(|e| anyhow!(e))?;
+
+        Ok(Self { token: jwt })
+    }
+
+    /// Borrow the inner JWT string.
+    pub fn as_str(&self) -> &str {
+        &self.token
+    }
+
+    /// Decode and validate the token, returning the underlying [`Claims`].
+    pub fn claims(&self, secret: &str) -> Result<Claims> {
+        Ok(Self::decode_internal(&self.token, secret)?.claims)
+    }
+
+    /// Fast authenticity + expiry check.
+    ///
+    /// The underlying `jsonwebtoken` validation treats a token whose `exp`
+    /// timestamp is **equal** to the current Unix time as *still valid*.
+    /// For our use-case we want a stricter policy – a token is considered
+    /// invalid the *moment* we reach its expiry second.  We therefore perform
+    /// an extra comparison on the decoded claims after signature/auth checks
+    /// succeed.
+    pub fn is_valid(&self, secret: &str) -> bool {
+        let data = match Self::decode_internal(&self.token, secret) {
+            Ok(d) => d,
+            Err(_) => return false,
+        };
+
+        // Strict expiration check (no leeway, strictly before `exp`).
+        let now = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(d) => d.as_secs() as usize,
+            Err(_) => return false, // system clock before epoch – treat as invalid
+        };
+        now < data.claims.exp
+    }
+
+    fn decode_internal(token: &str, secret: &str) -> std::result::Result<TokenData<Claims>, jsonwebtoken::errors::Error> {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.validate_exp = true;
+        validation.leeway = 0;
+        decode::<Claims>(
+            token,
+            &DecodingKey::from_secret(secret.as_bytes()),
+            &validation,
+        )
+    }
+}

--- a/crates/toka-capability/src/validator.rs
+++ b/crates/toka-capability/src/validator.rs
@@ -1,0 +1,52 @@
+//! Token validation traits & implementations
+//!
+//! This module intentionally mirrors the behaviour of `jsonwebtoken` but
+//! wraps it in a trait so that *callers stay decoupled from crypto choices*.
+//! Future versions may offer Paseto, Biscuit or custom MAC schemes behind the
+//! same interface.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+
+use crate::token::Claims;
+
+/// Generic validation behaviour for capability tokens.
+#[async_trait]
+pub trait TokenValidator: Send + Sync {
+    /// Verify `raw` token authenticity and semantic correctness.
+    ///
+    /// On success returns the decoded [`Claims`].
+    async fn validate(&self, raw: &str) -> Result<Claims>;
+}
+
+/// Symmetric-key JWT validator (HS256).
+#[derive(Clone, Debug)]
+pub struct JwtValidator {
+    secret: String,
+    validation: Validation,
+}
+
+impl JwtValidator {
+    /// Build a new validator using `secret`.  Accepts only HS256 for now.
+    pub fn new(secret: impl Into<String>) -> Self {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.validate_exp = true;
+        Self {
+            secret: secret.into(),
+            validation,
+        }
+    }
+}
+
+#[async_trait]
+impl TokenValidator for JwtValidator {
+    async fn validate(&self, raw: &str) -> Result<Claims> {
+        let data = decode::<Claims>(
+            raw,
+            &DecodingKey::from_secret(self.secret.as_bytes()),
+            &self.validation,
+        )?;
+        Ok(data.claims)
+    }
+}

--- a/crates/toka-capability/tests/security_tests.rs
+++ b/crates/toka-capability/tests/security_tests.rs
@@ -1,0 +1,68 @@
+//! Security-oriented tests for the new JWT-based `CapabilityToken` implementation (v0.2).
+
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+use toka_capability::CapabilityToken;
+
+const SECRET: &str = "test_secret_key_256_bits_long_for_testing";
+
+#[test]
+fn timing_attack_resistance() {
+    let token = CapabilityToken::new("user", "vault", vec!["read".into()], SECRET, 3600).unwrap();
+
+    let start_valid = Instant::now();
+    assert!(token.is_valid(SECRET));
+    let valid_duration = start_valid.elapsed();
+
+    let start_invalid = Instant::now();
+    assert!(!token.is_valid("wrong_secret"));
+    let invalid_duration = start_invalid.elapsed();
+
+    let diff = if valid_duration > invalid_duration {
+        valid_duration - invalid_duration
+    } else {
+        invalid_duration - valid_duration
+    };
+    // Allow small variance (< 2 ms)
+    assert!(diff < Duration::from_millis(2));
+}
+
+#[test]
+fn replay_attack_prevention() {
+    let token = CapabilityToken::new("user", "vault", vec!["read".into()], SECRET, 1).unwrap();
+    assert!(token.is_valid(SECRET));
+    thread::sleep(Duration::from_secs(2));
+    assert!(!token.is_valid(SECRET));
+}
+
+#[test]
+fn large_input_handling() {
+    let long_subject = "a".repeat(10_000);
+    let long_vault = "b".repeat(10_000);
+    let long_perm = vec!["c".repeat(10_000)];
+    let token = CapabilityToken::new(&long_subject, &long_vault, long_perm, SECRET, 3600).unwrap();
+    assert!(token.is_valid(SECRET));
+}
+
+#[test]
+fn concurrent_validation() {
+    let secret = Arc::new(SECRET.to_string());
+    let token = Arc::new(CapabilityToken::new("user", "vault", vec!["read".into()], secret.as_str(), 3600).unwrap());
+
+    let handles: Vec<_> = (0..10)
+        .map(|_| {
+            let t = Arc::clone(&token);
+            let s = Arc::clone(&secret);
+            thread::spawn(move || {
+                for _ in 0..100 {
+                    assert!(t.is_valid(s.as_str()));
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}

--- a/crates/toka-capability/tests/token_tests.rs
+++ b/crates/toka-capability/tests/token_tests.rs
@@ -1,0 +1,26 @@
+use std::thread;
+use std::time::Duration;
+use toka_capability::CapabilityToken;
+
+const SECRET: &str = "super_secret_key";
+
+#[test]
+fn token_roundtrip() {
+    let token = CapabilityToken::new("alice", "vault1", vec!["read".into()], SECRET, 3600).unwrap();
+    assert!(token.is_valid(SECRET));
+}
+
+#[test]
+fn invalid_secret_fails() {
+    let token = CapabilityToken::new("bob", "vault2", vec!["write".into()], SECRET, 3600).unwrap();
+    assert!(!token.is_valid("incorrect_secret"));
+}
+
+#[test]
+fn token_expires() {
+    let token = CapabilityToken::new("carol", "vault3", vec!["read".into()], SECRET, 1).unwrap();
+    assert!(token.is_valid(SECRET));
+    // Wait just over a second to ensure expiry has passed.
+    thread::sleep(Duration::from_millis(1100));
+    assert!(!token.is_valid(SECRET));
+}

--- a/crates/toka-cvm/Cargo.toml
+++ b/crates/toka-cvm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "toka-cvm"
+version = "0.2.0-alpha"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Capability Validation Module – host wrapper for verifying capabilities inside WASM guest modules."
+
+[dependencies]
+anyhow = { workspace = true }
+wasmtime = { version = "15", optional = true }
+
+[features]
+default = []
+wasm = ["dep:wasmtime"]

--- a/crates/toka-cvm/README.md
+++ b/crates/toka-cvm/README.md
@@ -1,0 +1,26 @@
+# Toka CVM (`toka-cvm`)
+
+> **Status**: Placeholder – not yet implemented
+
+`cvm` stands for **Capability Validation Module**.  The goal is to offer a
+host-side helper that verifies capability tokens *inside* guest WASM modules
+(exec'd via Wasmtime).  This allows untrusted user code to safely interact
+with Toka services while the host guarantees strict least authority.
+
+The crate currently ships *no code*; it merely reserves the namespace and
+lays down the groundwork for future post-quantum and agent-native security
+work.
+
+---
+
+## Planned Features
+
+* `validate(token: &str)` – minimal FFI boundary for guests.
+* **EdDSA** and **Biscuit** support once upstream.
+* Tight integration with `toka-capability` and `toka-revocation`.
+
+---
+
+## License
+
+Apache-2.0 OR MIT

--- a/crates/toka-cvm/src/lib.rs
+++ b/crates/toka-cvm/src/lib.rs
@@ -1,0 +1,7 @@
+//! Toka CVM – reserved for future capability validation logic.
+#![forbid(unsafe_code)]
+
+/// Placeholder function to silence `unused` warnings until the crate gains
+/// real functionality.
+#[allow(dead_code)]
+fn _placeholder() {}

--- a/crates/toka-revocation/Cargo.toml
+++ b/crates/toka-revocation/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "toka-revocation"
+version = "0.2.0-alpha"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Revocation primitives (RFC 7009) for capability tokens in the Toka platform."
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+chrono = { workspace = true }
+uuid = { workspace = true }
+parking_lot = { version = "0.12", optional = true }
+
+[features]
+default = ["memory-store"]
+
+# Simple in-memory store for testing / local dev.
+memory-store = ["dep:parking_lot"]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/toka-revocation/README.md
+++ b/crates/toka-revocation/README.md
@@ -1,0 +1,42 @@
+# Toka Revocation (`toka-revocation`)
+
+> **Status**: 0.2.0-alpha – experimental
+
+Primitives and interfaces for **revoking** capability tokens.  Implements the
+[RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) semantics while
+remaining optimised for *service-to-service* traffic inside the Toka runtime.
+
+This crate exposes:
+
+* `RevocationStore` – trait encapsulating the minimal operations (`revoke`,
+  `is_revoked`).
+* `MemoryStore` – default in-memory implementation behind the `memory-store`
+  feature for local development and unit tests.
+
+Production setups are expected to supply their own Postgres, Redis or
+HashiCorp Vault backed implementation.
+
+---
+
+## Example
+
+```rust,no_run
+use toka_revocation::RevocationStore;
+use toka_revocation::memory::MemoryStore; // default impl
+use uuid::Uuid;
+use chrono::{Utc, Duration};
+
+#[tokio::main]
+async fn main() {
+    let store = MemoryStore::new();
+    let jti = Uuid::new_v4();
+    store.revoke(jti, Utc::now() + Duration::minutes(15)).await.unwrap();
+    assert!(store.is_revoked(jti).await.unwrap());
+}
+```
+
+---
+
+## License
+
+Apache-2.0 OR MIT

--- a/crates/toka-revocation/src/lib.rs
+++ b/crates/toka-revocation/src/lib.rs
@@ -1,0 +1,84 @@
+#![forbid(unsafe_code)]
+//! Toka Revocation (v0.2-alpha)
+//!
+//! Pluggable revocation primitives for capability tokens.  The design follows
+//! [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) but remains
+//! opinionated for internal *service-to-service* workloads.
+//!
+//! The crate is intentionally small:
+//! * A single [`RevocationStore`] trait encapsulating the minimal operations.
+//! * A reference **in-memory** implementation behind the `memory-store`
+//!   feature flag (enabled by default).  Production deployments are expected
+//!   to bring their own Postgres/Redis-backed implementation.
+//!
+//! ## Roadmap
+//! * Redis store – constant-time look-ups with automatic key expiry.
+//! * Postgres store – transactional revocation + auditing.
+//! * gRPC & HTTP adapters under a sibling `toka-revocation-srv` crate.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+/// Contract for storing and querying *revoked* capability tokens.
+#[async_trait]
+pub trait RevocationStore: Send + Sync + 'static {
+    /// Persist a token identifier so subsequent validations can reject it.
+    async fn revoke(&self, jti: Uuid, expires_at: DateTime<Utc>) -> Result<()>;
+
+    /// Returns `true` if the token identifier has been revoked.
+    async fn is_revoked(&self, jti: Uuid) -> Result<bool>;
+}
+
+// -------------------------------------------------------------------------------------------------
+// In-memory store (dev/Test only)
+// -------------------------------------------------------------------------------------------------
+
+#[cfg(feature = "memory-store")]
+mod memory {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+
+    /// Non-persistent in-memory revocation list – suitable for tests only.
+    #[derive(Debug, Default)]
+    pub struct MemoryStore {
+        map: Mutex<HashMap<Uuid, DateTime<Utc>>>,
+    }
+
+    #[async_trait]
+    impl RevocationStore for MemoryStore {
+        async fn revoke(&self, jti: Uuid, expires_at: DateTime<Utc>) -> Result<()> {
+            self.map.lock().insert(jti, expires_at);
+            Ok(())
+        }
+
+        async fn is_revoked(&self, jti: Uuid) -> Result<bool> {
+            let map = self.map.lock();
+            Ok(map.get(&jti).map_or(false, |&exp| exp > Utc::now()))
+        }
+    }
+
+    impl MemoryStore {
+        /// Convenience helper for tests.
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[tokio::test]
+        async fn memory_store_roundtrip() {
+            let store = MemoryStore::new();
+            let jti = Uuid::new_v4();
+            let exp = Utc::now() + chrono::Duration::minutes(5);
+            assert!(!store.is_revoked(jti).await.unwrap());
+            store.revoke(jti, exp).await.unwrap();
+            assert!(store.is_revoked(jti).await.unwrap());
+        }
+    }
+}

--- a/crates/toka-runtime/Cargo.toml
+++ b/crates/toka-runtime/Cargo.toml
@@ -22,7 +22,7 @@ typetag = { version = "0.2", optional = true }
 toka-events = { path = "../toka-events", optional = true }
 toka-tools = { path = "../toka-tools", optional = true }
 toka-agents = { path = "../toka-agents", optional = true }
-toka-security-auth = { path = "../toka-security-auth", optional = true }
+toka-capability = { path = "../toka-capability", optional = true }
 toka-toolkit-core = { path = "../toka-toolkit-core", optional = true }
 toka-bus = { path = "../toka-bus" }
 toka-storage = { path = "../toka-storage" }
@@ -45,4 +45,4 @@ toolkit = ["toka-tools", "clap", "typetag", "toka-agents", "toka-agents/toolkit"
 # secure local event store
 vault = ["dep:toka-events", "rmp-serde"]
 # auth capability tokens utilities
-auth = ["toka-security-auth", "parking_lot"]
+auth = ["dep:toka-capability", "parking_lot"]

--- a/crates/toka-runtime/src/lib.rs
+++ b/crates/toka-runtime/src/lib.rs
@@ -8,7 +8,7 @@
 //! | Feature | Purpose | Additional crates |
 //! |---------|---------|-------------------|
 //! | `toolkit` *(opt)* | Enables [`ToolRegistry`](crate::tools) & default tools | `toka-toolkit-core`, `toka-tools` |
-//! | `auth` *(opt)*    | Capability-token validation & secret rotation | `toka-security-auth`, `jsonwebtoken` |
+//! | `auth` *(opt)*    | Capability-token validation & secret rotation | `toka-capability`, `jsonwebtoken` |
 //! | `vault` *(opt)*   | Embed the canonical event store | `toka-events` + `sled` |
 //!
 //! ## Quick-Start
@@ -27,7 +27,7 @@
 
 pub use toka_bus as events;
 #[cfg(feature = "auth")]
-pub use toka_security_auth as auth;
+pub use toka_capability as auth;
 #[cfg(all(feature = "toolkit", feature = "vault"))]
 #[doc(hidden)]
 pub mod runtime;

--- a/crates/toka-runtime/src/security.rs
+++ b/crates/toka-runtime/src/security.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use parking_lot::RwLock;
 use rand::{distributions::Alphanumeric, Rng};
-use toka_security_auth::prelude::{JwtValidator, TokenValidator};
+use toka_capability::prelude::{JwtValidator, TokenValidator};
 use tracing_subscriber::{fmt::MakeWriter, fmt, prelude::*};
 use std::io::{self, Write};
 
@@ -126,7 +126,7 @@ pub struct MultiValidator {
 
 #[async_trait::async_trait]
 impl TokenValidator for MultiValidator {
-    async fn validate(&self, raw: &str) -> Result<toka_security_auth::Claims> {
+    async fn validate(&self, raw: &str) -> Result<toka_capability::Claims> {
         for v in &self.validators {
             if let Ok(c) = v.validate(raw).await {
                 return Ok(c);

--- a/crates/toka/Cargo.toml
+++ b/crates/toka/Cargo.toml
@@ -10,7 +10,7 @@ description = "Top-level meta-crate that re-exports the most commonly used parts
 # Downstream users can cherry-pick (e.g. `default-features = false, features = ["auth"]`).
 default = ["auth", "events", "agents", "toolkit"]
 
-auth = ["dep:toka-security-auth"]
+auth = ["dep:toka-capability"]
 events = ["dep:toka-events"]
 agents = ["dep:toka-agents"]
 # toolkit feature exposes the default tools crate.
@@ -18,7 +18,7 @@ toolkit = ["dep:toka-toolkit-core", "dep:toka-tools"]
 
 [dependencies]
 # All dependencies are optional and tied to features above.
-toka-security-auth  = { path = "../toka-security-auth", optional = true }
+toka-capability     = { path = "../toka-capability", optional = true }
 toka-events         = { path = "../toka-events",         optional = true }
 toka-agents         = { path = "../toka-agents",         optional = true }
 toka-tools          = { path = "../toka-tools",          optional = true }

--- a/crates/toka/src/lib.rs
+++ b/crates/toka/src/lib.rs
@@ -14,7 +14,7 @@
 //! |------------|------------------------|------------------------|
 //! | **default** | `agents`, `auth`, `events`, `toolkit` | see below |
 //! | `agents`   | `toka-agents`        | `tokio`, `anyhow`, … |
-//! | `auth`     | `toka-security-auth` | `jsonwebtoken` |
+//! | `auth`     | `toka-capability`    | `jsonwebtoken` |
 //! | `events`   | `toka-events`        | `sled`, `blake3`, … |
 //! | `toolkit`  | `toka-toolkit-core` + `toka-tools` | `wasmtime` (optional) |
 //!
@@ -51,7 +51,7 @@ pub mod prelude {
     #[cfg(feature = "agents")]
     pub use toka_agents::prelude::*;
     #[cfg(feature = "auth")]
-    pub use toka_security_auth::prelude::*;
+    pub use toka_capability::prelude::*;
     #[cfg(feature = "events")]
     pub use toka_events::prelude::*;
     // Future: add toolkit prelude when available.
@@ -63,7 +63,7 @@ pub mod prelude {
 #[cfg(feature = "agents")]
 pub use toka_agents as agents;
 #[cfg(feature = "auth")]
-pub use toka_security_auth as auth;
+pub use toka_capability as auth;
 #[cfg(feature = "events")]
 pub use toka_events as events;
 #[cfg(feature = "toolkit")]


### PR DESCRIPTION
<!-- Introduce new `toka-capability`, `toka-revocation`, and `toka-cvm` crates as part of the v0.2-alpha security rewrite. -->

This PR re-organizes the security codebase, deprecating `toka-security-auth` (v0.1) and introducing dedicated crates for capability token management (`toka-capability`), revocation (`toka-revocation`), and future WASM-based validation (`toka-cvm`). This provides a cleaner, more decoupled architecture, aligning with the goal of using JWTs at the edge and capability tokens internally, and sets the stage for post-quantum and agent-native security features.