### PR TITLE
Refactor capability and auth crates

### DIFF
--- a/CRATES.md
+++ b/CRATES.md
@@ -10,6 +10,8 @@
 | `toka-memory-api`          | ① contract-only       | Trait contract for agent memory adapters (byte-oriented get/put/delete, no_std). |
 | `toka-storage-api`         | ① contract-only       | Async key–value artefact storage contract. |
 | `toka-security-auth`       | ① + ③                | Capability-token primitives and auth helpers (JWT, Paseto, etc.). |
+| `toka-capability-core`     | ① `no_std` primitives | Canonical Claims struct + capability traits (no crypto). |
+| `toka-capability-jwt-hs256`| ② implementation      | HS256 JWT implementation of capability tokens. |
 | `toka-agents`              | ② optional deps       | Default agent implementations for the runtime. |
 | `toka-toolkit-core`        | ① light, reusable     | Tool trait and registry abstractions (zero heavy deps). |
 | `toka-tools`               | ② optional deps       | Standard library of agent tools (currently minimal `echo`). |
@@ -20,6 +22,7 @@
 | `toka-runtime`             | ② heavy deps          | Async host tying agents, tools, bus & event store together. |
 | `toka`                     | – aggregate crate     | Meta-crate re-exporting common preludes for quick onboarding. |
 | `toka-cli` (app)           | ② heavy deps          | Command-line interface for interacting with the runtime. |
+| `toka-security-auth` (deprecated) | ① legacy           | Transitional re-export crate – will be removed after v0.3. |
 
 *Rule-of-Thumb Keys*
 ① Usable from `no_std` / lean targets  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ members = [
 
     # Primitives API (ids, currency)
     "crates/toka-primitives-api",
+
+    # New member
+    "crates/toka-capability-core",
+    "crates/toka-capability-jwt-hs256",
 ]
 
 [workspace.dependencies]

--- a/crates/toka-capability-core/Cargo.toml
+++ b/crates/toka-capability-core/Cargo.toml
@@ -7,7 +7,6 @@ description = "Core, no-std capability token primitives – Claims struct and ca
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-anyhow = { workspace = true }
 async-trait = { workspace = true }
 
 [features]

--- a/crates/toka-capability-core/Cargo.toml
+++ b/crates/toka-capability-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "toka-capability-core"
+version = "0.2.0-alpha"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Core, no-std capability token primitives – Claims struct and capability traits shared by all implementation crates."
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+
+[features]
+# Opt into no_std mode by disabling default std feature via --no-default-features
+default = ["std"]
+std = []

--- a/crates/toka-capability-core/src/lib.rs
+++ b/crates/toka-capability-core/src/lib.rs
@@ -1,0 +1,65 @@
+#![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+// When in no_std mode we need alloc for heap-backed types (String, Vec).
+#[cfg_attr(not(feature = "std"), macro_use)]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+#[cfg(feature = "std")]
+use std::{string::String, vec::Vec};
+
+use serde::{Deserialize, Serialize};
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Canonical claim-set used by capability tokens across the Toka platform.
+///
+/// This struct is intentionally *dumb*: it performs *no* validation, has
+/// *no* knowledge about cryptography or clocks and is fully `no_std`
+/// compatible (behind the `alloc` feature).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Claims {
+    /// Subject – usually the *user* or *agent* identifier.
+    pub sub: String,
+    /// Vault / workspace identifier the subject wishes to access.
+    pub vault: String,
+    /// Ordered list of permissions (e.g. `read`, `write`).
+    pub permissions: Vec<String>,
+    /// Issued-at timestamp (seconds since Unix epoch).
+    pub iat: u64,
+    /// Absolute expiry timestamp (seconds since Unix epoch).
+    pub exp: u64,
+    /// Unique token identifier (e.g. UUIDv4) for audit / replay-protection.
+    pub jti: String,
+}
+
+/// Behaviour common to **all** concrete capability token formats.
+///
+/// A token type implementing this trait is responsible for *encoding* the
+/// provided [`Claims`] into its wire format (e.g. a JWT string) and for
+/// *decoding* it back into the canonical struct.  The trait is deliberately
+/// small so that alternative algorithms (Biscuit, Paseto, …) can plug in
+/// without imposing additional dependencies.
+#[async_trait]
+pub trait CapabilityToken: Sized + Send + Sync {
+    /// Create a new token instance from raw claims and a secret / key.
+    async fn mint(claims: &Claims, key: &[u8]) -> Result<Self>;
+
+    /// Return the serialized wire-format representation (e.g. the raw JWT).
+    fn as_str(&self) -> &str;
+}
+
+/// Verification behaviour shared across the platform.
+#[async_trait]
+pub trait TokenValidator: Send + Sync {
+    /// Verify `raw` token authenticity and semantic correctness.
+    async fn validate(&self, raw: &str) -> Result<Claims>;
+}
+
+/// Convenience module collecting the most commonly used exports so that
+/// downstream crates only need a single `use` line.
+pub mod prelude {
+    pub use super::{Claims, CapabilityToken, TokenValidator};
+}

--- a/crates/toka-capability-core/src/lib.rs
+++ b/crates/toka-capability-core/src/lib.rs
@@ -11,8 +11,8 @@ use alloc::{string::String, vec::Vec};
 use std::{string::String, vec::Vec};
 
 use serde::{Deserialize, Serialize};
-use anyhow::Result;
 use async_trait::async_trait;
+use alloc::boxed::Box;
 
 /// Canonical claim-set used by capability tokens across the Toka platform.
 ///
@@ -34,6 +34,30 @@ pub struct Claims {
     /// Unique token identifier (e.g. UUIDv4) for audit / replay-protection.
     pub jti: String,
 }
+
+/// Result type used throughout **toka-capability-core**.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Minimal error type keeping the crate `no_std` + `alloc` friendly.
+#[derive(Debug)]
+pub struct Error {
+    msg: alloc::string::String,
+}
+
+impl Error {
+    pub fn new(msg: &str) -> Self {
+        Self { msg: msg.into() }
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.msg.fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 /// Behaviour common to **all** concrete capability token formats.
 ///

--- a/crates/toka-capability-jwt-hs256/Cargo.toml
+++ b/crates/toka-capability-jwt-hs256/Cargo.toml
@@ -7,7 +7,6 @@ description = "HS256 JWT implementation of Toka capability tokens (v0.2)."
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-anyhow = { workspace = true }
 async-trait = { workspace = true }
 jsonwebtoken = { workspace = true }
 uuid = { workspace = true }

--- a/crates/toka-capability-jwt-hs256/Cargo.toml
+++ b/crates/toka-capability-jwt-hs256/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "toka-capability-jwt-hs256"
+version = "0.2.0-alpha"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "HS256 JWT implementation of Toka capability tokens (v0.2)."
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+jsonwebtoken = { workspace = true }
+uuid = { workspace = true }
+toka-capability-core = { path = "../toka-capability-core" }
+
+[features]
+# std feature by default. Disable for no_std use-case.
+default = ["std"]
+std = []

--- a/crates/toka-capability-jwt-hs256/src/lib.rs
+++ b/crates/toka-capability-jwt-hs256/src/lib.rs
@@ -1,0 +1,22 @@
+#![forbid(unsafe_code)]
+
+//! `toka-capability-jwt-hs256` – concrete HS256 JWT capability token format.
+//!
+//! This crate wires the *pure* definitions from [`toka-capability-core`]
+//! onto the ubiquitous HS256 JSON Web Token algorithm, reusing the
+//! `jsonwebtoken` crate for the heavy lifting.
+//!
+//! Most users will only interact with [`JwtHs256Token`] and
+//! [`JwtHs256Validator`] or the glob import `toka_capability_jwt_hs256::prelude::*`.
+
+pub mod token;
+pub mod validator;
+
+pub mod prelude {
+    pub use super::token::JwtHs256Token;
+    pub use toka_capability_core::prelude::Claims;
+    pub use super::validator::{JwtHs256Validator};
+    pub use toka_capability_core::prelude::{TokenValidator, CapabilityToken};
+}
+
+pub use prelude::*;

--- a/crates/toka-capability-jwt-hs256/src/token.rs
+++ b/crates/toka-capability-jwt-hs256/src/token.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+use anyhow::{Result, anyhow};
+use jsonwebtoken::{encode, decode, Algorithm, Header, Validation, EncodingKey, DecodingKey, TokenData};
+use uuid::Uuid;
+use toka_capability_core::prelude::{Claims, CapabilityToken};
+use async_trait::async_trait;
+
+/// Concrete JWT (HS256) capability token implementation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JwtHs256Token {
+    token: String,
+}
+
+impl JwtHs256Token {
+    /// Decode and validate, returning Claims (strict expiry).
+    pub fn claims(&self, secret: &str) -> Result<Claims> {
+        Ok(Self::decode_internal(&self.token, secret)?.claims)
+    }
+
+    /// Authenticity + expiry quick check.
+    pub fn is_valid(&self, secret: &str) -> bool {
+        let data = match Self::decode_internal(&self.token, secret) {
+            Ok(d) => d,
+            Err(_) => return false,
+        };
+        let now = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(d) => d.as_secs() as u64,
+            Err(_) => return false,
+        };
+        now < data.claims.exp
+    }
+
+    fn decode_internal(token: &str, secret: &str) -> std::result::Result<TokenData<Claims>, jsonwebtoken::errors::Error> {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.validate_exp = true;
+        validation.leeway = 0;
+        decode::<Claims>(
+            token,
+            &DecodingKey::from_secret(secret.as_bytes()),
+            &validation,
+        )
+    }
+
+    /// Legacy helper kept for compatibility – *synchronous* shorthand that
+    /// mints a token with `subject`, `vault`, `permissions` and TTL.
+    pub fn new(subject: &str, vault_id: &str, permissions: Vec<String>, secret: &str, ttl_secs: u64) -> Result<Self> {
+        let claims = build_claims(subject, vault_id, permissions, ttl_secs)?;
+        // direct encode (internal helper) – reuse mint but synchronously via block_in_place? simpler duplicate logic.
+        let mut header = Header::new(Algorithm::HS256);
+        header.typ = Some("toka.cap+jwt".into());
+        let jwt = encode(&header, &claims, &EncodingKey::from_secret(secret.as_bytes()))
+            .map_err(|e| anyhow!(e))?;
+        Ok(Self { token: jwt })
+    }
+}
+
+#[async_trait]
+impl CapabilityToken for JwtHs256Token {
+    async fn mint(claims: &Claims, key: &[u8]) -> Result<Self> {
+        let mut header = Header::new(Algorithm::HS256);
+        header.typ = Some("toka.cap+jwt".into());
+        let jwt = encode(
+            &header,
+            claims,
+            &EncodingKey::from_secret(key),
+        ).map_err(|e| anyhow!(e))?;
+        Ok(Self { token: jwt })
+    }
+
+    fn as_str(&self) -> &str {
+        &self.token
+    }
+}
+
+/// Helper to build standard claims with right timestamps.
+pub fn build_claims(subject: &str, vault: &str, permissions: Vec<String>, ttl_secs: u64) -> Result<Claims> {
+    let issued_at = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    Ok(Claims {
+        sub: subject.to_owned(),
+        vault: vault.to_owned(),
+        permissions,
+        iat: issued_at,
+        exp: issued_at + ttl_secs,
+        jti: Uuid::new_v4().to_string(),
+    })
+}

--- a/crates/toka-capability-jwt-hs256/src/validator.rs
+++ b/crates/toka-capability-jwt-hs256/src/validator.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use toka_capability_core::prelude::{Claims, TokenValidator};
+
+/// HS256 JWT validator.
+#[derive(Clone, Debug)]
+pub struct JwtHs256Validator {
+    secret: String,
+    validation: Validation,
+}
+
+impl JwtHs256Validator {
+    pub fn new(secret: impl Into<String>) -> Self {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.validate_exp = true;
+        Self {
+            secret: secret.into(),
+            validation,
+        }
+    }
+}
+
+#[async_trait]
+impl TokenValidator for JwtHs256Validator {
+    async fn validate(&self, raw: &str) -> Result<Claims> {
+        let data = decode::<Claims>(
+            raw,
+            &DecodingKey::from_secret(self.secret.as_bytes()),
+            &self.validation,
+        )?;
+        Ok(data.claims)
+    }
+}

--- a/crates/toka-capability-jwt-hs256/src/validator.rs
+++ b/crates/toka-capability-jwt-hs256/src/validator.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
 use async_trait::async_trait;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use toka_capability_core::prelude::{Claims, TokenValidator};
+use toka_capability_core::{Result, Error};
 
 /// HS256 JWT validator.
 #[derive(Clone, Debug)]
@@ -28,7 +28,7 @@ impl TokenValidator for JwtHs256Validator {
             raw,
             &DecodingKey::from_secret(self.secret.as_bytes()),
             &self.validation,
-        )?;
+        ).map_err(|e| Error::new(&e.to_string()))?;
         Ok(data.claims)
     }
 }

--- a/crates/toka-capability/Cargo.toml
+++ b/crates/toka-capability/Cargo.toml
@@ -3,16 +3,15 @@ name = "toka-capability"
 version = "0.2.0-alpha"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-description = "Capability token primitives (v0.2) for internal auth across the Toka platform."
+# Mark crate as deprecated for Cargo (cargo's convention)
+[package.metadata]
+deprecated = true
 
 [dependencies]
-serde = { workspace = true, features = ["derive"] }
-anyhow = { workspace = true }
-async-trait = { workspace = true }
-jsonwebtoken = { workspace = true }
-uuid = { workspace = true }
+# Re-export from new crate and core.
+toka-capability-core = { path = "../toka-capability-core" }
+toka-capability-jwt-hs256 = { path = "../toka-capability-jwt-hs256" }
 
 [features]
-# Core primitives only by default. In the future we may expose `biscuits`, `paseto`, etc.
-default = ["core"]
-core = []
+# `legacy-v0_1` feature re-exports old API names if needed.
+legacy-v0_1 = []

--- a/crates/toka-capability/src/lib.rs
+++ b/crates/toka-capability/src/lib.rs
@@ -1,33 +1,20 @@
 #![forbid(unsafe_code)]
-//! Toka Capability – v0.2 primitives
-//!
-//! This crate provides *no-std*-friendly primitives for **capability tokens**
-//! that internal Toka services use for authorisation.  The public interface is
-//! deliberately small and stable so that downstream crates can swap the
-//! underlying crypto or transport without major refactors.
-//!
-//! ## Versioning
-//! This is the **0.2-alpha** rewrite that supersedes the former
-//! `toka-security-auth` crate (v0.1).  It aligns with the draft
-//! specification in `docs/40_capability_tokens_spec_v0.1.md` and introduces
-//! cleaner boundaries ready for future extensions like EdDSA, Biscuit and
-//! opaque-token revocation.
-//!
-//! Differences to v0.1:
-//! * Crate renamed to `toka-capability`.
-//! * Moved revocation & CVM concerns into sibling crates so this one stays
-//!   focused on **creation** and **validation** only.
-//! * Internal validation API tightened – no more default clock leeway.
-//!
-//! ---
-//! This crate is memory safe (no `unsafe`) and has **zero required runtime
-//! allocations** on the happy path.
+#![deprecated(note = "toka-capability has been split into toka-capability-core + toka-capability-jwt-hs256. Depend on those crates directly.")]
 
-pub mod token;
-pub mod validator;
+//! DEPRECATED – use `toka-capability-core` + `toka-capability-jwt-hs256` instead.
 
-pub mod prelude;
+pub use toka_capability_core as core;
+pub use toka_capability_jwt_hs256::*;
 
-pub use prelude::*;
+// Backwards compatibility: keep original names via re-export.
+pub use toka_capability_core::prelude::Claims;
+pub use toka_capability_jwt_hs256::token::JwtHs256Token as CapabilityToken;
+pub use toka_capability_jwt_hs256::validator::JwtHs256Validator as JwtValidator;
+// Keep selective re-exports to avoid naming clashes.
+pub use toka_capability_core::prelude::{TokenValidator};
 
-pub use token::CapabilityToken;
+/// Prelude retaining the legacy (v0.1) surface while delegating to new crates.
+pub mod prelude {
+    pub use super::{Claims, CapabilityToken, JwtValidator};
+    pub use toka_capability_core::prelude::TokenValidator;
+}

--- a/crates/toka-runtime/src/security.rs
+++ b/crates/toka-runtime/src/security.rs
@@ -17,12 +17,12 @@
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use anyhow::Result;
 use parking_lot::RwLock;
 use rand::{distributions::Alphanumeric, Rng};
 use toka_capability::prelude::{JwtValidator, TokenValidator};
 use tracing_subscriber::{fmt::MakeWriter, fmt, prelude::*};
 use std::io::{self, Write};
+use toka_capability::core::{Result, Error as CapError};
 
 /// Maximum number of retired secrets kept alive for validation.
 const MAX_OLD_SECRETS: usize = 4;
@@ -132,7 +132,7 @@ impl TokenValidator for MultiValidator {
                 return Ok(c);
             }
         }
-        Err(anyhow::anyhow!("token validation failed for all secrets"))
+        Err(CapError::new("token validation failed for all secrets"))
     }
 }
 

--- a/crates/toka-security-auth/Cargo.toml
+++ b/crates/toka-security-auth/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Lightweight capability-token primitives for Toka platform auth."
+[package.metadata]
+deprecated = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/docs/40_capability_tokens_spec_v0.1.md
+++ b/docs/40_capability_tokens_spec_v0.1.md
@@ -1,6 +1,7 @@
 # Capability Tokens – v0.1 Specification
+# Capability Tokens – v0.2 Specification
 
-> Status: **Draft–Ready** | Version: 0.1 | Last-updated: 2025-06-29
+> Status: **Stable** | Version: 0.2 | Last-updated: 2025-06-29
 
 ---
 
@@ -23,11 +24,7 @@ The remainder of this document focuses on the *internal* flavour.
 
 ## 2  Token Format
 
-Internally we encode capabilities as JSON Web Tokens (RFC 7519) because:
-
-1. Ubiquitous library support – no bespoke crypto.
-2. Self-contained claims; no round-trip to a database on every call.
-3. Compact, URL-safe, human-readable for debugging.
+Internally we encode capabilities as JSON Web Tokens (RFC 7519) by default via the *HS256* implementation crate [`toka-capability-jwt-hs256`]. Alternative algorithms can be plugged in without affecting this spec.
 
 ### 2.1  Header
 
@@ -109,19 +106,18 @@ let claims = validator.validate(token.as_str()).await?;
 assert_eq!(claims.vault, "vault_123");
 ```
 
-The full API lives in `crates/toka-security-auth`.
+The reference Rust implementation lives in `crates/toka-capability-jwt-hs256` with the shared traits residing in `crates/toka-capability-core`.
 
 ---
 
 ## 7  Compatibility & Migration
 
-Nothing to migrate; v0.1 is the first public release. Future version 0.2 will add:
+The transition from v0.1 to v0.2 is *source compatible* for most callers via the legacy re-export crate `toka-capability`.
 
+New features slated for v0.3:
 * EdDSA signing & verification.
 * Optional Biscuit token format with offline delegation.
 * Opaque-token mode backed by Postgres for instant revocation.
-
-All additions will be *backwards compatible*.
 
 ---
 

--- a/docs/41_capability_tokens_architecture.md
+++ b/docs/41_capability_tokens_architecture.md
@@ -1,0 +1,78 @@
+# Capability Tokens – Three-Tier Architecture (v0.2)
+
+> This document complements `40_capability_tokens_spec_v0.2.md` and explains **how** the Rust crates map onto the spec.
+
+---
+
+## 1  Overview
+
+```
+          ┌────────────┐
+          │  Services  │  ← Agents, Runtime, Auth-svc, CVM …
+          └────┬───────┘
+               │ uses
+               ▼
+        ┌──────────────────┐
+        │  Implementation  │  (`toka-capability-jwt-hs256`, `jwt-eddsa`, …)
+        └────┬─────────────┘
+             │ implements
+             ▼
+     ┌──────────────────────┐
+     │       Core           │  (`toka-capability-core`)
+     └──────────────────────┘
+```
+
+* **Core** – pure, `no_std`, owns `Claims` & the two fundamental traits (`CapabilityToken`, `TokenValidator`).
+* **Implementation** – brings crypto & std, produces concrete structs (e.g. `JwtHs256Token`).
+* **Adapters / Services** – I/O, storage, gRPC, Wasmtime, etc. Never touch crypto.
+
+---
+
+## 2  Crate Responsibilities
+
+| Crate | Tier | `#![no_std]`? | Responsibility |
+|-------|------|-------------|----------------|
+| `toka-capability-core` | Core | ✅ (`alloc`) | Canonical data-model & traits. |
+| `toka-capability-jwt-hs256` | Impl | 🚫 (needs `SystemTime`, `jsonwebtoken`) | HS256 JWT encoder / validator. |
+| `toka-revocation` | Adapter | 🚫 | RFC 7009 stores (memory / redis / pg). |
+| `toka-cvm` | Adapter | 🚫 | Host helper for validating tokens inside WASM guests. |
+
+---
+
+## 3  Feature Flags
+
+```
+[toka-capability-core]
+default = ["std"]   # disable for embedded targets
+
+[toka-capability-jwt-hs256]
+default = ["std"]   # alloc-only mode coming in v0.3
+```
+
+---
+
+## 4  Migration Cheatsheet
+
+1. **Library / embedded code** → depend on `toka-capability-core` *only* and accept a generic `impl TokenValidator`.
+2. **Micro-services** → add `toka-capability-jwt-hs256` (or another impl) and construct the concrete validator.
+3. **Old `toka-security-auth` users** → update `Cargo.toml`:
+
+```toml
+# Before
+[dependencies]
+toka-security-auth = "0.1"
+
+# After (temporary shim still works but shows warning)
+[dependencies]
+toka-capability = "0.2"           # deprecated shim
+# or migrate directly
+# toka-capability-jwt-hs256 = "0.2"
+```
+
+---
+
+## 5  Roadmap
+
+* v0.3 – `toka-capability-jwt-eddsa` (EdDSA/Ed25519) + alloc-only HS256 build.
+* v0.4 – Biscuit support with attenuation and offline delegation.
+* v1.0 – Stabilise public API and freeze wire-format for long-term compatibility.


### PR DESCRIPTION
Refactor capability/auth crates into a three-tier architecture to improve modularity, clarify responsibilities, and enhance future extensibility.

This change establishes `toka-capability-core` as the single source of truth for `Claims` and core traits, eliminating redundancy. It creates clear boundaries between protocol definitions, cryptographic implementations (`toka-capability-jwt-hs256`), and higher-level adapters, making the system more future-proof for new algorithms and revocation back-ends.